### PR TITLE
refactor: change behaviour for disabled state

### DIFF
--- a/src/VueToggles.vue
+++ b/src/VueToggles.vue
@@ -62,6 +62,10 @@ export default {
       type: String,
       default: '#5850ec',
     },
+    disabledOpacity: {
+      type: [String, Number],
+      default: '0.75',
+    },
     dotColor: {
       type: String,
       default: '#fff',
@@ -88,7 +92,9 @@ export default {
       const styles = {
         width: `${this.width}px`,
         height: `${this.height}px`,
-        background: this.value && !this.disabled ? this.checkedBg : this.uncheckedBg,
+        background: this.value ? this.checkedBg : this.uncheckedBg,
+        opacity: this.disabled ? this.disabledOpacity : 1,
+        cursor: !this.disabled ? 'pointer' : 'not-allowed',
       };
 
       return styles;
@@ -136,7 +142,6 @@ export default {
 
 <style>
 .vue-toggles {
-  cursor: pointer;
   display: flex;
   align-items: center;
   border-radius: 9999px;


### PR DESCRIPTION
Due to the way the disabled state is handled, a toggle will get the same color as unchecked as well as the cursor remaining to be a pointer. 

Too improve the UX I applied an opacity to the checkedBg color for better visibility and changed the icon to not-allowed as you would expect with a disabled element.